### PR TITLE
[bug] update the current playlist from the media callback

### DIFF
--- a/src/FPPPixelRadio.cpp
+++ b/src/FPPPixelRadio.cpp
@@ -304,6 +304,13 @@ public:
         int track = mediaDetails.track;
         int length = mediaDetails.length;
         
+        if( playlist["name"].asString().compare(currentPlaylist) != 0 ) {
+            LogDebug(VB_PLUGIN, "Setting currentplaylist to %s because it's currently %s\n", playlist["name"].asString().c_str(), currentPlaylist.c_str());
+            currentPlaylist = playlist["name"].asString();
+            
+        }
+
+
         std::string type = playlist["currentEntry"]["type"].asString();
         if (type != "both" && type != "media") {
             title = "";


### PR DESCRIPTION
Because FPP doesn't send a start on resume, we need to get the current playlist from the media callback. This allows for back and forth between the pauseable playlist and an interruption to work correctly.